### PR TITLE
Add option to ignore endstops during encoder index search

### DIFF
--- a/Firmware/MotorControl/axis.cpp
+++ b/Firmware/MotorControl/axis.cpp
@@ -153,9 +153,9 @@ bool Axis::do_checks(uint32_t timestamp) {
     motor_.do_checks(timestamp);
 
     // Check for endstop presses
-    if (min_endstop_.config_.enabled && min_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING) && !(min_endstop_.config_.ignore_during_startup && current_state_ == AXIS_STATE_UNDEFINED)) {
+    if (min_endstop_.config_.enabled && min_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING) && !(min_endstop_.config_.ignore_during_startup && current_state_ == AXIS_STATE_UNDEFINED) && !(min_endstop_.config_.ignore_during_encoder_index_search && current_state_ == AXIS_STATE_ENCODER_INDEX_SEARCH)) {
         error_ |= ERROR_MIN_ENDSTOP_PRESSED;
-    } else if (max_endstop_.config_.enabled && max_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING) && !(max_endstop_.config_.ignore_during_startup && current_state_ == AXIS_STATE_UNDEFINED)) {
+    } else if (max_endstop_.config_.enabled && max_endstop_.rose() && !(current_state_ == AXIS_STATE_HOMING) && !(max_endstop_.config_.ignore_during_startup && current_state_ == AXIS_STATE_UNDEFINED) && !(min_endstop_.config_.ignore_during_encoder_index_search && current_state_ == AXIS_STATE_ENCODER_INDEX_SEARCH)) {
         error_ |= ERROR_MAX_ENDSTOP_PRESSED;
     }
 

--- a/Firmware/MotorControl/endstop.hpp
+++ b/Firmware/MotorControl/endstop.hpp
@@ -11,6 +11,7 @@ class Endstop {
         bool enabled = false;
         bool is_active_high = false;
         bool ignore_during_startup = false;
+        bool ignore_during_encoder_index_search = false;
 
         // custom setters
         Endstop* parent = nullptr;

--- a/Firmware/odrive-interface.yaml
+++ b/Firmware/odrive-interface.yaml
@@ -1410,6 +1410,7 @@ interfaces:
           offset: {type: float32, unit: turns}
           is_active_high: bool
           ignore_during_startup: bool
+          ignore_during_encoder_index_search: bool
           debounce_ms: {type: uint32, c_setter: set_debounce_ms}
 
   ODrive.MechanicalBrake:


### PR DESCRIPTION
This is useful for devices where the endstop is pressed while power is off, due to gravity, springs, or otherwise. When combined with #747, this allows the ODrive to start up the motors and perform the encoder index search while one of the endstops is pressed. With this setting enabled, the limit switch will not cause the motor to disarm during the encoder index search, making the `odrive.axis*.config.startup_encoder_index_search` flag useful again.